### PR TITLE
Add storefront-id header to API requests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22643,7 +22643,7 @@
     },
     "packages/cli": {
       "name": "@shopify/cli-hydrogen",
-      "version": "4.0.0-alpha.11",
+      "version": "4.0.0-alpha.12",
       "dependencies": {
         "@oclif/core": "^1.20.4",
         "@remix-run/dev": "1.12.0",
@@ -22704,9 +22704,9 @@
     },
     "packages/create-hydrogen": {
       "name": "@shopify/create-hydrogen",
-      "version": "4.0.0-alpha.2",
+      "version": "4.0.0-alpha.3",
       "dependencies": {
-        "@shopify/cli-hydrogen": "^4.0.0-alpha.11"
+        "@shopify/cli-hydrogen": "^4.0.0-alpha.12"
       },
       "bin": {
         "create-hydrogen": "dist/create-app.js"
@@ -22714,7 +22714,7 @@
     },
     "packages/hydrogen": {
       "name": "@shopify/hydrogen",
-      "version": "2023.1.0-alpha.1",
+      "version": "2023.1.0-alpha.2",
       "dependencies": {
         "@shopify/hydrogen-react": "2023.1.4"
       },
@@ -22828,7 +22828,7 @@
     },
     "packages/remix-oxygen": {
       "name": "@shopify/remix-oxygen",
-      "version": "1.0.0-alpha.3",
+      "version": "1.0.0-alpha.4",
       "dependencies": {
         "@remix-run/server-runtime": "1.12.0"
       },
@@ -22845,9 +22845,9 @@
         "@headlessui/react": "^1.7.2",
         "@remix-run/react": "1.12.0",
         "@shopify/cli": "3.29.0",
-        "@shopify/cli-hydrogen": "^4.0.0-alpha.11",
-        "@shopify/hydrogen": "^2023.1.0-alpha.1",
-        "@shopify/remix-oxygen": "^1.0.0-alpha.3",
+        "@shopify/cli-hydrogen": "^4.0.0-alpha.12",
+        "@shopify/hydrogen": "^2023.1.0-alpha.2",
+        "@shopify/remix-oxygen": "^1.0.0-alpha.4",
         "clsx": "^1.2.1",
         "concurrently": "^7.5.0",
         "cross-env": "^7.0.3",
@@ -22895,9 +22895,9 @@
       "dependencies": {
         "@remix-run/react": "1.12.0",
         "@shopify/cli": "3.29.0",
-        "@shopify/cli-hydrogen": "^4.0.0-alpha.11",
-        "@shopify/hydrogen": "^2023.1.0-alpha.1",
-        "@shopify/remix-oxygen": "^1.0.0-alpha.3",
+        "@shopify/cli-hydrogen": "^4.0.0-alpha.12",
+        "@shopify/hydrogen": "^2023.1.0-alpha.2",
+        "@shopify/remix-oxygen": "^1.0.0-alpha.4",
         "graphql": "^16.6.0",
         "graphql-tag": "^2.12.6",
         "react": "^18.2.0",
@@ -26340,7 +26340,7 @@
     "@shopify/create-hydrogen": {
       "version": "file:packages/create-hydrogen",
       "requires": {
-        "@shopify/cli-hydrogen": "^4.0.0-alpha.11"
+        "@shopify/cli-hydrogen": "^4.0.0-alpha.12"
       }
     },
     "@shopify/eslint-plugin": {
@@ -28989,12 +28989,12 @@
         "@remix-run/eslint-config": "1.12.0",
         "@remix-run/react": "1.12.0",
         "@shopify/cli": "3.29.0",
-        "@shopify/cli-hydrogen": "^4.0.0-alpha.11",
+        "@shopify/cli-hydrogen": "^4.0.0-alpha.12",
         "@shopify/eslint-plugin": "^42.0.1",
-        "@shopify/hydrogen": "^2023.1.0-alpha.1",
+        "@shopify/hydrogen": "^2023.1.0-alpha.2",
         "@shopify/oxygen-workers-types": "^3.17.2",
         "@shopify/prettier-config": "^1.1.2",
-        "@shopify/remix-oxygen": "^1.0.0-alpha.3",
+        "@shopify/remix-oxygen": "^1.0.0-alpha.4",
         "@tailwindcss/forms": "^0.5.3",
         "@tailwindcss/typography": "^0.5.7",
         "@types/eslint": "^8.4.10",
@@ -30814,11 +30814,11 @@
         "@remix-run/dev": "1.12.0",
         "@remix-run/react": "1.12.0",
         "@shopify/cli": "3.29.0",
-        "@shopify/cli-hydrogen": "^4.0.0-alpha.11",
-        "@shopify/hydrogen": "^2023.1.0-alpha.1",
+        "@shopify/cli-hydrogen": "^4.0.0-alpha.12",
+        "@shopify/hydrogen": "^2023.1.0-alpha.2",
         "@shopify/oxygen-workers-types": "^3.17.2",
         "@shopify/prettier-config": "^1.1.2",
-        "@shopify/remix-oxygen": "^1.0.0-alpha.3",
+        "@shopify/remix-oxygen": "^1.0.0-alpha.4",
         "@types/eslint": "^8.4.10",
         "@types/react": "^18.0.20",
         "@types/react-dom": "^18.0.6",

--- a/packages/hydrogen/src/constants.ts
+++ b/packages/hydrogen/src/constants.ts
@@ -1,3 +1,4 @@
 export const STOREFRONT_REQUEST_GROUP_ID_HEADER =
   'Custom-Storefront-Request-Group-ID';
 export const STOREFRONT_API_BUYER_IP_HEADER = 'Shopify-Storefront-Buyer-IP';
+export const STOREFRONT_ID_HEADER = 'Shopify-Storefront-Id';

--- a/packages/hydrogen/src/storefront.ts
+++ b/packages/hydrogen/src/storefront.ts
@@ -6,6 +6,7 @@ import type {ExecutionArgs} from 'graphql';
 import {fetchWithServerCache, checkGraphQLErrors} from './cache/fetch';
 import {
   STOREFRONT_API_BUYER_IP_HEADER,
+  STOREFRONT_ID_HEADER,
   STOREFRONT_REQUEST_GROUP_ID_HEADER,
 } from './constants';
 import {
@@ -74,6 +75,7 @@ export type CreateStorefrontClientOptions<TI18n extends I18nBase> = Parameters<
   cache?: Cache;
   buyerIp?: string;
   requestGroupId?: string;
+  storefrontId?: string;
   waitUntil?: ExecutionContext['waitUntil'];
   i18n?: TI18n;
 };
@@ -121,6 +123,7 @@ export function createStorefrontClient<TI18n extends I18nBase>({
   buyerIp,
   i18n,
   requestGroupId = generateUUID(),
+  storefrontId,
   ...clientOptions
 }: CreateStorefrontClientOptions<TI18n>): StorefrontClient<TI18n> {
   if (!cache) {
@@ -145,6 +148,7 @@ export function createStorefrontClient<TI18n extends I18nBase>({
 
   defaultHeaders[STOREFRONT_REQUEST_GROUP_ID_HEADER] = requestGroupId;
   if (buyerIp) defaultHeaders[STOREFRONT_API_BUYER_IP_HEADER] = buyerIp;
+  if (storefrontId) defaultHeaders[STOREFRONT_ID_HEADER] = storefrontId;
 
   async function fetchStorefrontApi<T>({
     query,

--- a/templates/demo-store/remix.env.d.ts
+++ b/templates/demo-store/remix.env.d.ts
@@ -20,6 +20,7 @@ declare global {
     PRIVATE_STOREFRONT_API_TOKEN: string;
     PUBLIC_STOREFRONT_API_VERSION: string;
     PUBLIC_STORE_DOMAIN: string;
+    PUBLIC_STOREFRONT_ID: string;
   }
 }
 

--- a/templates/demo-store/server.ts
+++ b/templates/demo-store/server.ts
@@ -40,6 +40,7 @@ export default {
         privateStorefrontToken: env.PRIVATE_STOREFRONT_API_TOKEN,
         storeDomain: `https://${env.PUBLIC_STORE_DOMAIN}`,
         storefrontApiVersion: env.PUBLIC_STOREFRONT_API_VERSION || '2023-01',
+        storefrontId: env.PUBLIC_STOREFRONT_ID,
       });
 
       /**

--- a/templates/hello-world/remix.env.d.ts
+++ b/templates/hello-world/remix.env.d.ts
@@ -20,6 +20,7 @@ declare global {
     PRIVATE_STOREFRONT_API_TOKEN: string;
     PUBLIC_STOREFRONT_API_VERSION: string;
     PUBLIC_STORE_DOMAIN: string;
+    PUBLIC_STOREFRONT_ID: string;
   }
 }
 

--- a/templates/hello-world/server.ts
+++ b/templates/hello-world/server.ts
@@ -44,6 +44,7 @@ export default {
         privateStorefrontToken: env.PRIVATE_STOREFRONT_API_TOKEN,
         storeDomain: `https://${env.PUBLIC_STORE_DOMAIN}`,
         storefrontApiVersion: env.PUBLIC_STOREFRONT_API_VERSION || '2023-01',
+        storefrontId: env.PUBLIC_STOREFRONT_ID,
       });
 
       /**

--- a/templates/skeleton/remix.env.d.ts
+++ b/templates/skeleton/remix.env.d.ts
@@ -20,6 +20,7 @@ declare global {
     PRIVATE_STOREFRONT_API_TOKEN: string;
     PUBLIC_STOREFRONT_API_VERSION: string;
     PUBLIC_STORE_DOMAIN: string;
+    PUBLIC_STOREFRONT_ID: string;
   }
 }
 

--- a/templates/skeleton/server.ts
+++ b/templates/skeleton/server.ts
@@ -44,6 +44,7 @@ export default {
         privateStorefrontToken: env.PRIVATE_STOREFRONT_API_TOKEN,
         storeDomain: env.PUBLIC_STORE_DOMAIN,
         storefrontApiVersion: env.PUBLIC_STOREFRONT_API_VERSION || '2022-10',
+        storefrontId: env.PUBLIC_STOREFRONT_ID,
       });
 
       /**


### PR DESCRIPTION
Fixes https://github.com/Shopify/h2/issues/439

Alternatively this change could be applied in hydrogen-react, but I only think that the storefront-id is defined on Oxygen, which isn't supported for wider frameworks that use hydrogen-react.