### PR TITLE
CLI tweaks

### DIFF
--- a/packages/cli/src/commands/hydrogen/build.ts
+++ b/packages/cli/src/commands/hydrogen/build.ts
@@ -7,6 +7,7 @@ import Command from '@shopify/cli-kit/node/base-command';
 import Flags from '@oclif/core/lib/flags.js';
 import {checkLockfileStatus} from '../../utils/check-lockfile.js';
 import {findMissingRoutes} from '../../utils/missing-routes.js';
+import {getPackageManager} from '@shopify/cli-kit/node/node-package-manager';
 
 const LOG_WORKER_BUILT = '📦 Worker built';
 
@@ -91,7 +92,12 @@ export async function runBuild({
 
     if (sizeMB >= 1) {
       output.warn(
-        '🚨 Worker bundle exceeds 1 MB! This can delay your worker response.\n',
+        `🚨 Warning: worker bundle exceeds 1 MB! This can delay your worker response.${
+          // @ts-ignore
+          remixConfig.serverMinify
+            ? ''
+            : ' Minify your bundle by adding `serverMinify: true` to remix.config.js.'
+        }\n`,
       );
     }
   }
@@ -99,8 +105,11 @@ export async function runBuild({
   if (!disableRouteWarning) {
     const missingRoutes = findMissingRoutes(remixConfig);
     if (missingRoutes.length) {
+      const packageManager = await getPackageManager(root);
+      const exec = packageManager === 'npm' ? 'npx' : packageManager;
+
       output.warn(
-        '🚨 Standard Shopify routes missing; run `shopify hydrogen check routes` for more details.',
+        `🚨 Warning: standard Shopify routes missing; run \`${exec} shopify hydrogen check routes\` for more details.\n`,
       );
     }
   }

--- a/packages/cli/src/commands/hydrogen/build.ts
+++ b/packages/cli/src/commands/hydrogen/build.ts
@@ -110,7 +110,7 @@ export async function runBuild({
 
       output.warn(
         `Heads up: Shopify stores have a number of standard routes that aren’t set up yet.\n` +
-          `Some functionality and backlinks might not work as expected until these are created, or redirects are set up.\n` +
+          `Some functionality and backlinks might not work as expected until these are created or redirects are set up.\n` +
           `This build is missing ${missingRoutes.length} route${
             missingRoutes.length > 1 ? 's' : ''
           }. For more details, run \`${exec} shopify hydrogen check routes\`.\n`,

--- a/packages/cli/src/commands/hydrogen/build.ts
+++ b/packages/cli/src/commands/hydrogen/build.ts
@@ -92,7 +92,7 @@ export async function runBuild({
 
     if (sizeMB >= 1) {
       output.warn(
-        `🚨 Warning: worker bundle exceeds 1 MB! This can delay your worker response.${
+        `🚨 Worker bundle exceeds 1 MB! This can delay your worker response.${
           // @ts-ignore
           remixConfig.serverMinify
             ? ''
@@ -109,7 +109,11 @@ export async function runBuild({
       const exec = packageManager === 'npm' ? 'npx' : packageManager;
 
       output.warn(
-        `🚨 Warning: standard Shopify routes missing; run \`${exec} shopify hydrogen check routes\` for more details.\n`,
+        `Heads up: Shopify stores have a number of standard routes that aren’t set up yet.\n` +
+          `Some functionality and backlinks might not work as expected until these are created, or redirects are set up.\n` +
+          `This build is missing ${missingRoutes.length} route${
+            missingRoutes.length > 1 ? 's' : ''
+          }. For more details, run \`${exec} shopify hydrogen check routes\`.\n`,
       );
     }
   }

--- a/packages/cli/src/utils/check-lockfile.ts
+++ b/packages/cli/src/utils/check-lockfile.ts
@@ -82,11 +82,15 @@ export async function checkLockfileStatus(directory: string) {
     return multipleLockfilesWarning(availableLockfiles);
   }
 
-  const repo = git.factory(directory);
-  const lockfile = availableLockfiles[0]!;
-  const ignoredLockfile = await repo.checkIgnore([lockfile]);
+  try {
+    const repo = git.factory(directory);
+    const lockfile = availableLockfiles[0]!;
+    const ignoredLockfile = await repo.checkIgnore([lockfile]);
 
-  if (ignoredLockfile.length) {
-    lockfileIgnoredWarning(lockfile);
+    if (ignoredLockfile.length) {
+      lockfileIgnoredWarning(lockfile);
+    }
+  } catch {
+    // Not a Git repository, ignore
   }
 }

--- a/packages/cli/src/utils/mini-oxygen.ts
+++ b/packages/cli/src/utils/mini-oxygen.ts
@@ -1,5 +1,4 @@
-import path from 'path';
-import {output} from '@shopify/cli-kit';
+import {output, path, file} from '@shopify/cli-kit';
 import colors from '@shopify/cli-kit/node/colors';
 
 type MiniOxygenOptions = {
@@ -21,6 +20,8 @@ export async function startMiniOxygen({
   const miniOxygenPreview =
     miniOxygen.default ?? (miniOxygen as unknown as typeof miniOxygen.default);
 
+  const dotenvPath = path.resolve(root, '.env');
+
   const {port: actualPort} = await miniOxygenPreview({
     workerFile: buildPathWorkerFile,
     assetsDir: buildPathClient,
@@ -30,7 +31,7 @@ export async function startMiniOxygen({
     autoReload: watch,
     modules: true,
     env: process.env,
-    envPath: path.resolve(root, '.env'),
+    envPath: (await file.exists(dotenvPath)) ? dotenvPath : undefined,
     log: () => {},
     buildWatchPaths: watch
       ? [path.resolve(root, buildPathWorkerFile)]

--- a/packages/cli/src/utils/missing-routes.ts
+++ b/packages/cli/src/utils/missing-routes.ts
@@ -84,7 +84,7 @@ export function findMissingRoutes(config: RemixConfig) {
   return [...requiredRoutes];
 }
 
-const LINE_LIMIT = 10;
+const LINE_LIMIT = 100;
 export function logMissingRoutes(routes: string[]) {
   if (routes.length) {
     renderWarning({

--- a/packages/cli/src/utils/missing-routes.ts
+++ b/packages/cli/src/utils/missing-routes.ts
@@ -90,7 +90,9 @@ export function logMissingRoutes(routes: string[]) {
     renderWarning({
       headline: 'Standard Shopify routes missing',
       body:
-        'Your Hydrogen project is missing some standard Shopify routes. ' +
+        `Your Hydrogen project is missing ${
+          routes.length
+        } standard Shopify route${routes.length > 1 ? 's' : ''}.\n` +
         'Including these routes improves compatibility with Shopify’s platform:\n\n' +
         routes
           .slice(0, LINE_LIMIT - (routes.length <= LINE_LIMIT ? 0 : 1))

--- a/templates/demo-store/README.md
+++ b/templates/demo-store/README.md
@@ -1,6 +1,6 @@
-# Hydrogen template: Hello World
+# Hydrogen template: Demo Store
 
-Hydrogen is Shopify’s stack for headless commerce. Hydrogen is designed to dovetail with [Remix](https://remix.run/), Shopify’s full stack web framework. This template contains a **minimal setup** of components, queries and tooling to get started with Hydrogen.
+Hydrogen is Shopify’s stack for headless commerce. Hydrogen is designed to dovetail with [Remix](https://remix.run/), Shopify’s full stack web framework. This template contains **full-featured setup** of components, queries and tooling to get started with Hydrogen.
 
 [Check out Hydrogen docs](https://shopify.dev/custom-storefronts/hydrogen)
 [Get familiar with Remix](https://remix.run/docs/en/v1)
@@ -14,7 +14,8 @@ Hydrogen is Shopify’s stack for headless commerce. Hydrogen is designed to dov
 - Prettier
 - GraphQL generator
 - TypeScript and JavaScript flavors
-- Minimal setup of components and routes
+- Tailwind CSS (via PostCSS)
+- Full-featured setup of components and routes
 
 ## Getting started
 
@@ -23,7 +24,7 @@ Hydrogen is Shopify’s stack for headless commerce. Hydrogen is designed to dov
 - Node.js version 16.14.0 or higher
 
 ```bash
-npm create @shopify/hydrogen@latest --template hello-world
+npm create @shopify/hydrogen@latest --template demo-store
 ```
 
 Remember to update `.env` with your shop's domain and Storefront API token!

--- a/templates/demo-store/README.md
+++ b/templates/demo-store/README.md
@@ -1,6 +1,6 @@
 # Hydrogen template: Demo Store
 
-Hydrogen is Shopify’s stack for headless commerce. Hydrogen is designed to dovetail with [Remix](https://remix.run/), Shopify’s full stack web framework. This template contains **full-featured setup** of components, queries and tooling to get started with Hydrogen.
+Hydrogen is Shopify’s stack for headless commerce. Hydrogen is designed to dovetail with [Remix](https://remix.run/), Shopify’s full stack web framework. This template contains a **full-featured setup** of components, queries and tooling to get started with Hydrogen.
 
 [Check out Hydrogen docs](https://shopify.dev/custom-storefronts/hydrogen)
 [Get familiar with Remix](https://remix.run/docs/en/v1)

--- a/templates/demo-store/README.md
+++ b/templates/demo-store/README.md
@@ -10,6 +10,7 @@ Hydrogen is Shopify’s stack for headless commerce. Hydrogen is designed to dov
 - Remix
 - Hydrogen
 - Oxygen
+- Shopify CLI
 - ESLint
 - Prettier
 - GraphQL generator

--- a/templates/hello-world/README.md
+++ b/templates/hello-world/README.md
@@ -10,6 +10,7 @@ Hydrogen is Shopify’s stack for headless commerce. Hydrogen is designed to dov
 - Remix
 - Hydrogen
 - Oxygen
+- Shopify CLI
 - ESLint
 - Prettier
 - GraphQL generator


### PR DESCRIPTION
Fixing some stuff reported in multiple places:

- Change wording for some warnings
- Show the package manager prefix in the check-routes command (`[npx|pnpm|yarn] shopify hydrogen check routes`)
- Show all missing routes in the check-routes command
- Do not throw errors on projects without Git
- Prevent MiniOxygen from crashing when `.env` doesn't exist
- Add readme.md to templates

Fixes #427 