### PR TITLE
Remove unused properties in hydrogen#package.json

### DIFF
--- a/packages/hydrogen/package.json
+++ b/packages/hydrogen/package.json
@@ -34,12 +34,6 @@
         "default": "./dist/production/index.js"
       }
     },
-    "./build": {
-      "types": "./dist/build/index.d.ts",
-      "require": "./dist/build/index.cjs",
-      "import": "./dist/build/index.js",
-      "default": "./dist/build/index.js"
-    },
     "./storefront-api-types": "./dist/storefront-api-types.d.ts",
     "./storefront.schema.json": "./dist/storefront.schema.json",
     "./package.json": "./package.json"


### PR DESCRIPTION
The `./build` export is a leftover from the `.hydrogen` directory feature.