### PR TITLE
Upgrade Typescript

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,11 +22,11 @@
         "cross-env": "^7.0.3",
         "eslint": "^8.20.0",
         "lint-staged": "^10.5.4",
-        "prettier": "^2.7.1",
+        "prettier": "^2.8.4",
         "rimraf": "^3.0.2",
         "tsup": "^6.5.0",
         "turbo": "^1.6.3",
-        "typescript": "^4.8.3",
+        "typescript": "^4.9.5",
         "yorkie": "^2.0.0"
       },
       "engines": {
@@ -4439,6 +4439,20 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/@remix-run/dev/node_modules/prettier": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.7.1.tgz",
+      "integrity": "sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==",
+      "bin": {
+        "prettier": "bin-prettier.js"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
     "node_modules/@remix-run/dev/node_modules/strip-final-newline": {
       "version": "2.0.0",
       "license": "MIT",
@@ -4974,6 +4988,20 @@
       "integrity": "sha512-RjhtfwJOxzcFmNOi6ltcbcu4Iu+FL3zEj83dk4kAS+fVpTxXLO1b38RvJgT/0QwvV/L3aY9TAnyv0EOqW4GoMQ==",
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      }
+    },
+    "node_modules/@shopify/cli-kit/node_modules/prettier": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.7.1.tgz",
+      "integrity": "sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==",
+      "bin": {
+        "prettier": "bin-prettier.js"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/@shopify/cli-kit/node_modules/react": {
@@ -17513,8 +17541,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "2.7.1",
-      "license": "MIT",
+      "version": "2.8.4",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.4.tgz",
+      "integrity": "sha512-vIS4Rlc2FNh0BySk3Wkd6xmwxB0FpOndW5fisM5H8hsZSxU2VWVB5CWIkIjWvrHjIhxk2g3bfMKM87zNTrZddw==",
       "bin": {
         "prettier": "bin-prettier.js"
       },
@@ -20765,8 +20794,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.9.3",
-      "license": "Apache-2.0",
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -22652,10 +22682,10 @@
         "fast-glob": "^3.2.12",
         "fs-extra": "^10.1.0",
         "gunzip-maybe": "^1.4.2",
-        "prettier": "^2.8.2",
+        "prettier": "^2.8.4",
         "recursive-readdir": "^2.2.3",
         "tar-fs": "^2.1.1",
-        "typescript": "^4.8.3"
+        "typescript": "^4.9.5"
       },
       "bin": {
         "cli-hydrogen": "dist/create-app.js"
@@ -22718,19 +22748,6 @@
       },
       "engines": {
         "node": ">=8.6.0"
-      }
-    },
-    "packages/cli/node_modules/prettier": {
-      "version": "2.8.3",
-      "license": "MIT",
-      "bin": {
-        "prettier": "bin-prettier.js"
-      },
-      "engines": {
-        "node": ">=10.13.0"
-      },
-      "funding": {
-        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "packages/create-hydrogen": {
@@ -22912,10 +22929,10 @@
         "postcss-cli": "^10.0.0",
         "postcss-import": "^15.0.0",
         "postcss-preset-env": "^7.8.2",
-        "prettier": "^2.7.1",
+        "prettier": "^2.8.4",
         "rimraf": "^3.0.2",
         "tailwindcss": "^3.1.8",
-        "typescript": "^4.8.3"
+        "typescript": "^4.9.5"
       },
       "engines": {
         "node": ">=16.13"
@@ -22943,8 +22960,8 @@
         "@types/react-dom": "^18.0.6",
         "eslint": "^8.20.0",
         "eslint-plugin-hydrogen": "0.12.2",
-        "prettier": "^2.7.1",
-        "typescript": "^4.8.3"
+        "prettier": "^2.8.4",
+        "typescript": "^4.9.5"
       },
       "engines": {
         "node": ">=16.13"
@@ -25811,6 +25828,11 @@
             "mimic-fn": "^2.1.0"
           }
         },
+        "prettier": {
+          "version": "2.7.1",
+          "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.7.1.tgz",
+          "integrity": "sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g=="
+        },
         "strip-final-newline": {
           "version": "2.0.0"
         }
@@ -26000,11 +26022,11 @@
         "fs-extra": "^10.1.0",
         "gunzip-maybe": "^1.4.2",
         "oclif": "^3.4.2",
-        "prettier": "^2.8.2",
+        "prettier": "^2.8.4",
         "recursive-readdir": "^2.2.3",
         "tar-fs": "^2.1.1",
         "tempy": "^3.0.0",
-        "typescript": "^4.8.3",
+        "typescript": "^4.9.5",
         "vitest": "^0.28.1"
       },
       "dependencies": {
@@ -26019,9 +26041,6 @@
             "merge2": "^1.3.0",
             "micromatch": "^4.0.4"
           }
-        },
-        "prettier": {
-          "version": "2.8.3"
         }
       }
     },
@@ -26316,6 +26335,11 @@
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-5.0.0.tgz",
           "integrity": "sha512-RjhtfwJOxzcFmNOi6ltcbcu4Iu+FL3zEj83dk4kAS+fVpTxXLO1b38RvJgT/0QwvV/L3aY9TAnyv0EOqW4GoMQ=="
+        },
+        "prettier": {
+          "version": "2.7.1",
+          "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.7.1.tgz",
+          "integrity": "sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g=="
         },
         "react": {
           "version": "17.0.2",
@@ -29043,7 +29067,7 @@
         "postcss-cli": "^10.0.0",
         "postcss-import": "^15.0.0",
         "postcss-preset-env": "^7.8.2",
-        "prettier": "^2.7.1",
+        "prettier": "^2.8.4",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-intersection-observer": "^9.4.1",
@@ -29052,7 +29076,7 @@
         "schema-dts": "^1.1.0",
         "tailwindcss": "^3.1.8",
         "tiny-invariant": "^1.2.0",
-        "typescript": "^4.8.3",
+        "typescript": "^4.9.5",
         "typographic-base": "^1.0.4"
       }
     },
@@ -30857,10 +30881,10 @@
         "eslint-plugin-hydrogen": "0.12.2",
         "graphql": "^16.6.0",
         "graphql-tag": "^2.12.6",
-        "prettier": "^2.7.1",
+        "prettier": "^2.8.4",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
-        "typescript": "^4.8.3"
+        "typescript": "^4.9.5"
       }
     },
     "hosted-git-info": {
@@ -34114,7 +34138,9 @@
       "dev": true
     },
     "prettier": {
-      "version": "2.7.1"
+      "version": "2.8.4",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.4.tgz",
+      "integrity": "sha512-vIS4Rlc2FNh0BySk3Wkd6xmwxB0FpOndW5fisM5H8hsZSxU2VWVB5CWIkIjWvrHjIhxk2g3bfMKM87zNTrZddw=="
     },
     "prettier-linter-helpers": {
       "version": "1.0.0",
@@ -36154,7 +36180,9 @@
       }
     },
     "typescript": {
-      "version": "4.9.3"
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g=="
     },
     "typographic-apostrophes": {
       "version": "1.1.1"

--- a/package.json
+++ b/package.json
@@ -30,11 +30,11 @@
     "cross-env": "^7.0.3",
     "eslint": "^8.20.0",
     "lint-staged": "^10.5.4",
-    "prettier": "^2.7.1",
+    "prettier": "^2.8.4",
     "rimraf": "^3.0.2",
     "tsup": "^6.5.0",
     "turbo": "^1.6.3",
-    "typescript": "^4.8.3",
+    "typescript": "^4.9.5",
     "yorkie": "^2.0.0"
   },
   "engines": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -36,10 +36,10 @@
     "fast-glob": "^3.2.12",
     "fs-extra": "^10.1.0",
     "gunzip-maybe": "^1.4.2",
-    "prettier": "^2.8.2",
+    "prettier": "^2.8.4",
     "recursive-readdir": "^2.2.3",
     "tar-fs": "^2.1.1",
-    "typescript": "^4.8.3"
+    "typescript": "^4.9.5"
   },
   "bin": "dist/create-app.js",
   "exports": {

--- a/templates/demo-store/package.json
+++ b/templates/demo-store/package.json
@@ -53,10 +53,10 @@
     "postcss-cli": "^10.0.0",
     "postcss-import": "^15.0.0",
     "postcss-preset-env": "^7.8.2",
-    "prettier": "^2.7.1",
+    "prettier": "^2.8.4",
     "rimraf": "^3.0.2",
     "tailwindcss": "^3.1.8",
-    "typescript": "^4.8.3"
+    "typescript": "^4.9.5"
   },
   "engines": {
     "node": ">=16.13"

--- a/templates/hello-world/package.json
+++ b/templates/hello-world/package.json
@@ -32,8 +32,8 @@
     "@types/react-dom": "^18.0.6",
     "eslint": "^8.20.0",
     "eslint-plugin-hydrogen": "0.12.2",
-    "prettier": "^2.7.1",
-    "typescript": "^4.8.3"
+    "prettier": "^2.8.4",
+    "typescript": "^4.9.5"
   },
   "engines": {
     "node": ">=16.13"

--- a/templates/skeleton/package.json
+++ b/templates/skeleton/package.json
@@ -31,8 +31,8 @@
     "@types/react-dom": "^18.0.6",
     "eslint": "^8.20.0",
     "eslint-plugin-hydrogen": "0.12.2",
-    "typescript": "^4.8.3",
-    "prettier": "^2.7.1"
+    "typescript": "^4.9.5",
+    "prettier": "^2.8.4"
   },
   "engines": {
     "node": ">=16.13"


### PR DESCRIPTION
This PR brings us to typescript `^4.9.5` which allows for `satisfies` and is consistent with `hydrogen-react`. I also updated `prettier` because it wasn't able to understand the final comma dangle before the `satisfies` keyword. If this all build successfully in CI, it should be safe to merge.