### PR TITLE
Fix tests and run them in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,3 +67,27 @@ jobs:
 
       - name: 🧑‍💻 CLI manifest check
         run: 'test -z "$(git status --porcelain "packages/cli/oclif.manifest.json" )" || { echo -e "Run npm generate:manifest in packages/cli before pushing new commands or flags. Diff here:\n\n$(git diff)" ; exit 1; }'
+
+  test:
+    name: ⬣ Test
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    concurrency:
+      group: ci-test-${{ github.ref }}
+      cancel-in-progress: true
+    steps:
+      - name: ⬇️ Checkout repo
+        uses: actions/checkout@v3
+
+      - name: ⎔ Setup node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+          cache: 'npm'
+          cache-dependency-path: '**/package-lock.json'
+
+      - name: 📥 Install dependencies
+        run: npm ci
+
+      - name: 🔬 Test
+        run: npm run test

--- a/package.json
+++ b/package.json
@@ -10,6 +10,8 @@
     "lint": "eslint --no-error-on-unmatched-pattern --ext .js,.ts,.jsx,.tsx ./packages && npm run lint -w demo-store",
     "format": "prettier --write --ignore-unknown ./packages && npm run format -w demo-store",
     "typecheck": "turbo typecheck --parallel",
+    "test": "turbo run test --parallel",
+    "test:watch": "turbo run test:watch",
     "version": "changeset version && node -p \"'export const LIB_VERSION = \\'' + require('./packages/hydrogen/package.json').version + '\\';'\" > packages/hydrogen/src/version.ts",
     "changeset": "changeset",
     "clean-all": "rimraf node_modules/.bin && rimraf node_modules/.cache && rimraf packages/remix-oxygen/dist && rimraf packages/hydrogen/dist && rimraf packages/cli/dist && rimraf templates/demo-store/.cache"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -11,7 +11,8 @@
     "dev": "tsup --watch --config ./tsup.config.ts",
     "typecheck": "tsc --noEmit",
     "generate:manifest": "oclif manifest",
-    "test": "vitest"
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "devDependencies": {
     "@types/fs-extra": "^9.0.13",

--- a/packages/cli/src/commands/hydrogen/generate/route.test.ts
+++ b/packages/cli/src/commands/hydrogen/generate/route.test.ts
@@ -1,6 +1,6 @@
 import {describe, it, expect, vi, beforeEach} from 'vitest';
 import {temporaryDirectoryTask} from 'tempy';
-import {runGenerate} from './route.js';
+import {runGenerate, GENERATOR_TEMPLATES_DIR} from './route.js';
 import {file, path, ui} from '@shopify/cli-kit';
 
 describe('generate/route', () => {
@@ -27,7 +27,7 @@ describe('generate/route', () => {
       const route = 'pages/$pageHandle';
       const {appRoot, templatesRoot} = await createHydrogen(tmpDir, {
         files: [],
-        templates: [[route, 'const str = "hello world"']],
+        templates: [[route, `const str = "hello world"`]],
       });
 
       // When
@@ -37,10 +37,9 @@ describe('generate/route', () => {
       });
 
       // Then
-      const extension = '.jsx';
       expect(
         await file.read(path.join(appRoot, 'app/routes', `${route}.jsx`)),
-      ).toContain('const str = "hello world"');
+      ).toContain(`const str = 'hello world'`);
     });
   });
 
@@ -61,10 +60,9 @@ describe('generate/route', () => {
       });
 
       // Then
-      const extension = '.tsx';
       expect(
         await file.read(path.join(appRoot, 'app/routes', `${route}.tsx`)),
-      ).toContain('const str = "hello typescript"');
+      ).toContain(`const str = 'hello typescript'`);
     });
   });
 
@@ -143,7 +141,12 @@ async function createHydrogen(
 
   for (const item of templates) {
     const [filePath, fileContent] = item;
-    const fullFilePath = path.join(directory, 'templates', `${filePath}.tsx`);
+    const fullFilePath = path.join(
+      directory,
+      GENERATOR_TEMPLATES_DIR,
+      'routes',
+      `${filePath}.tsx`,
+    );
     await file.mkdir(path.dirname(fullFilePath));
     await file.write(fullFilePath, fileContent);
   }

--- a/packages/cli/src/commands/hydrogen/generate/route.ts
+++ b/packages/cli/src/commands/hydrogen/generate/route.ts
@@ -11,6 +11,8 @@ import {
   resolveFormatConfig,
 } from '../../../utils/transpile-ts.js';
 
+export const GENERATOR_TEMPLATES_DIR = 'generator-templates';
+
 // Fix for a TypeScript bug:
 // https://github.com/microsoft/TypeScript/issues/42873
 import type {} from '@oclif/core/lib/interfaces/parser.js';
@@ -143,7 +145,7 @@ export async function runGenerate(
   const extension = typescript ? '.tsx' : '.jsx';
   const templatePath = path.join(
     templatesRoot,
-    'generator-templates',
+    GENERATOR_TEMPLATES_DIR,
     'routes',
     `${route}.tsx`,
   );

--- a/packages/hydrogen/package.json
+++ b/packages/hydrogen/package.json
@@ -15,7 +15,8 @@
     "copy-hydrogen-react": "cp ../../node_modules/@shopify/hydrogen-react/storefront.schema.json dist && cp ../../node_modules/@shopify/hydrogen-react/dist/types/storefront-api-types.d.ts dist",
     "dev": "tsup --watch --config ../../tsup.config.ts",
     "typecheck": "tsc --noEmit",
-    "test": "vitest"
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "exports": {
     ".": {

--- a/turbo.json
+++ b/turbo.json
@@ -21,9 +21,9 @@
       "outputs": [],
       "dependsOn": ["build"]
     },
-    "test": {
-      "outputs": [],
-      "dependsOn": ["build"]
+    "test": {},
+    "test:watch": {
+      "cache": false
     },
     "demo-store#build": {
       "dependsOn": [


### PR DESCRIPTION
The CLI tests have been broken for a week because we are not actually running `vitest` in CI. This PR both fixes the tests and adds an action to run them in the CI pipeline. I also added some changes to our turbo config to support this.

If everything passes in CI, this should be good and safe to merge.

We can fuss over the emojis later 🙂 