### PR TITLE
Sync release cycle branch with main

### DIFF
--- a/.github/workflows/sync_main.yml
+++ b/.github/workflows/sync_main.yml
@@ -3,7 +3,7 @@ name: Sync to main
 on:
   push:
     branches:
-      - 'v0.x-2022-10'
+      - '2023-01'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
We should fix this because:
- Having a consistently named branch is helpful for permalinks.
- It is a convenience for folks coming into the repo and unfamiliar with calver.
- Muscle memory for git commands (like `rebase` or `checkout`) will still behave predictably.
- Keeps the repo from having a `main` branch that is 100s of commits behind the default branch.

All I did was change the name of the workflow branch to trigger this action, which I think will be enough.